### PR TITLE
change 'rule_overrides' input variable

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -10,7 +10,7 @@ variable "rules_to_include" {
 variable "rule_overrides" {
   description = "Override the configuration for any managed rule"
   default     = {}
-  type        = map(any)
+  type        = any
 }
 
 variable "rule_packs" {


### PR DESCRIPTION
Because the shape/type of the `rule_overrides` input variable can change depending on how it is created or generated outside of this module (either as a map or an object), this variable's type needs to be set to `any`.