### PR TITLE
add exclude rule packs

### DIFF
--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -13,6 +13,12 @@ module "managed_rules" {
     "Operational-Best-Practices-for-NIST-800-53-rev-4",
   ]
 
+  rule_packs_rules_to_exclude = [
+    "Operational-Best-Practices-for-CIS-AWS-v1.4-Level1",
+    "Operational-Best-Practices-for-CIS-AWS-v1.4-Level2",
+  ]
+
+
   # Extra rules not included in the Packs you want to deploy
   rules_to_include = [
     "dax-encryption-enabled",

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -13,7 +13,7 @@ module "managed_rules" {
     "Operational-Best-Practices-for-NIST-800-53-rev-4",
   ]
 
-  rule_packs_rules_to_exclude = [
+  rule_packs_to_exclude = [
     "Operational-Best-Practices-for-CIS-AWS-v1.4-Level1",
     "Operational-Best-Practices-for-CIS-AWS-v1.4-Level2",
   ]

--- a/locals.tf
+++ b/locals.tf
@@ -6,6 +6,11 @@ locals {
     local.pack_file["packs"][pack]
   ]
 
+  rule_packs_rules_to_exclude = [
+    for pack in var.rule_packs_rules_to_exclude :
+    local.pack_file["packs"][pack]
+  ]
+
   rules_collected = sort(
     distinct(
       flatten(
@@ -17,9 +22,20 @@ locals {
     )
   )
 
+  rules_exclude_collected = sort(
+    distinct(
+      flatten(
+        concat(
+          var.rules_to_exclude,
+          local.rule_packs_rules_to_exclude
+        )
+      )
+    )
+  )
+
   final_rules = [
     for rule in local.rules_collected :
-    rule if !contains(var.rules_to_exclude, rule)
+    rule if !contains(local.rules_exclude_collected, rule)
   ]
 
   final_managed_rules = merge(local.managed_rules, var.rule_overrides)

--- a/locals.tf
+++ b/locals.tf
@@ -6,8 +6,8 @@ locals {
     local.pack_file["packs"][pack]
   ]
 
-  rule_packs_rules_to_exclude = [
-    for pack in var.rule_packs_rules_to_exclude :
+  rule_packs_to_exclude = [
+    for pack in var.rule_packs_to_exclude :
     local.pack_file["packs"][pack]
   ]
 
@@ -27,7 +27,7 @@ locals {
       flatten(
         concat(
           var.rules_to_exclude,
-          local.rule_packs_rules_to_exclude
+          local.rule_packs_to_exclude
         )
       )
     )

--- a/variables.tf
+++ b/variables.tf
@@ -19,10 +19,9 @@ variable "rule_packs" {
   type        = list(string)
 }
 
-# in cases where rules from other packs overalap and
-# lets say we want to exlude all overalap rules from a pack.. this feature should address that
-# Example usecase is where securityhub deploys CIS Level1 and 2 Rules and lets say
-# we want to exlcude all these rules from NIST pack
+# In cases where rules from other packs overlap and let's say we want to exclude all overlap rules from a pack.. 
+# this feature should address that. Example use case is where securityhub deploys CIS Level1 and 2 Rules and 
+# lets say we want to exclude all these rules from NIST pack
 variable "rule_packs_rules_to_exclude" {
   description = "A list of Rule Packs (based off AWS Conformance Packs) from which overlap rules to exclude"
   default     = []

--- a/variables.tf
+++ b/variables.tf
@@ -19,6 +19,16 @@ variable "rule_packs" {
   type        = list(string)
 }
 
+# in cases where rules from other packs overalap and
+# lets say we want to exlude all overalap rules from a pack.. this feature should address that
+# Example usecase is where securityhub deploys CIS Level1 and 2 Rules and lets say
+# we want to exlcude all these rules from NIST pack
+variable "rule_packs_rules_to_exclude" {
+  description = "A list of Rule Packs (based off AWS Conformance Packs) from which overlap rules to exclude"
+  default     = []
+  type        = list(string)
+}
+
 variable "rules_to_exclude" {
   description = "A list of individual AWS-managed Config Rules to exclude from deployment"
   default     = []

--- a/variables.tf
+++ b/variables.tf
@@ -22,7 +22,7 @@ variable "rule_packs" {
 # In cases where rules from other packs overlap and let's say we want to exclude all overlap rules from a pack.. 
 # this feature should address that. Example use case is where securityhub deploys CIS Level1 and 2 Rules and 
 # lets say we want to exclude all these rules from NIST pack
-variable "rule_packs_rules_to_exclude" {
+variable "rule_packs_to_exclude" {
   description = "A list of Rule Packs (based off AWS Conformance Packs) from which overlap rules to exclude"
   default     = []
   type        = list(string)


### PR DESCRIPTION
Feature to exclude overlap rules from a pack.

In cases where rules from other packs overlap and let's say we want to exclude all overlap rules from a pack.. this feature should address that. Example use case is where securityhub deploys CIS Level1 and 2 Rules and lets say we want to exclude all these rules from NIST pack