### PR TITLE
Fixed incorrect relative paths set in index.py

### DIFF
--- a/scripts/index.py
+++ b/scripts/index.py
@@ -8,9 +8,10 @@ from lib.hcl_reader import read_hcl_file
 
 ROOT_PAGE = 'https://docs.aws.amazon.com/config/latest/developerguide/'
 AWS_MANAGED_RULES_PAGE = ROOT_PAGE + 'managed-rules-by-aws-config.html'
-SOURCE_FILE_NAME = Path('config_rule_data.json')
-LOCALS_FILE_PATH = Path('..', '..', 'managed_rules_locals.tf')
-VARIABLES_FILE_PATH = Path('..', '..', 'managed_rules_variables.tf')
+CURRENT_DIR = Path(__file__).resolve().parent
+SOURCE_FILE_NAME = Path(CURRENT_DIR, 'config_rule_data.json')
+LOCALS_FILE_PATH = Path(CURRENT_DIR, '..', 'managed_rules_locals.tf').resolve()
+VARIABLES_FILE_PATH = Path(CURRENT_DIR, '..', 'managed_rules_variables.tf').resolve()
 
 if __name__ == '__main__':
     # Scrape AWS documentation for the latest Config Rules.


### PR DESCRIPTION
There was an issue in the latest run of the `Update Config Rules` workflow:

```
Writing result to config_rule_data.json.
File not found:  [Errno 2] No such file or directory: '../../managed_rules_locals.tf'
Traceback (most recent call last):
  File "/home/runner/work/terraform-aws-managed-config-rules/terraform-aws-managed-config-rules/scripts/index.py", line 24, in <module>
    for _, local in enumerate(data['locals']):
KeyError: 'locals'
Error: Process completed with exit code 1.
```

I've updated the file paths to use the `scripts` directory to build absolute paths to the `managed_rules_locals.tf` and `managed_rules_variables.tf` files.

Here is a successful run of the updated workflow: https://github.com/niaid/terraform-aws-managed-config-rules/actions/runs/9208135752/job/25329687982