### PR TITLE
remove, add and fix a few rules

### DIFF
--- a/files/pack-rules.yaml
+++ b/files/pack-rules.yaml
@@ -2069,11 +2069,10 @@ packs:
   - aws-config-process-check
   - backup-recovery-point-encrypted
   - cloud-trail-cloud-watch-logs-enabled
-  - cloud-trail-enabled
+  - cloudtrail-enabled
   - cloud-trail-encryption-enabled
   - cloudtrail-s3-dataevents-enabled
   - codebuild-project-artifact-encryption
-  - codebuild-project-environment-privileged-check
   - codebuild-project-envvar-awscred-check
   - codebuild-project-logging-enabled
   - codebuild-project-source-repo-url-check
@@ -2136,6 +2135,7 @@ packs:
   - iam-user-unused-credentials-check
   - incoming-ssh-disabled
   - instances-in-vpc
+  - lambda-concurrency-check
   - lambda-function-public-access-prohibited
   - lambda-inside-vpc
   - mfa-enabled-for-iam-console-access
@@ -5933,7 +5933,7 @@ packs:
   - autoscaling-launch-config-public-ip-disabled
   - beanstalk-enhanced-health-reporting-enabled
   - cloud-trail-cloud-watch-logs-enabled
-  - cloud-trail-enabled
+  - cloudtrail-enabled
   - cloud-trail-encryption-enabled
   - cloud-trail-log-file-validation-enabled
   - cloudtrail-s3-dataevents-enabled


### PR DESCRIPTION
some rules need to be updated, here are a few so far: 
1. cloudtrail-enabled rule name was wrong
2. codebuild-project-environment-privileged-check has been removed from all security standards since Apr. 10th, 2024. 
3. lambda-concurrency-check rule should be added back