### PR TITLE
Fix rule overrides

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -38,8 +38,13 @@ locals {
     rule if !contains(local.rules_exclude_collected, rule)
   ]
 
+  combined_rules = {
+    for rule in distinct(concat(keys(local.managed_rules), keys(var.rule_overrides))) :
+    rule => lookup(local.managed_rules, rule, lookup(var.rule_overrides, rule, {}))
+  }
+
   final_managed_rules = {
-    for rule, attr in local.managed_rules :
+    for rule, attr in local.combined_rules :
     rule => merge(attr, lookup(var.rule_overrides, rule, {}))
   }
 

--- a/locals.tf
+++ b/locals.tf
@@ -38,7 +38,10 @@ locals {
     rule if !contains(local.rules_exclude_collected, rule)
   ]
 
-  final_managed_rules = merge(local.managed_rules, var.rule_overrides)
+  final_managed_rules = {
+    for rule, attr in local.managed_rules :
+    rule => merge(attr, lookup(var.rule_overrides, rule, {}))
+  }
 
   rules_to_apply = {
     for rule, attr in local.final_managed_rules :

--- a/modules/account/main.tf
+++ b/modules/account/main.tf
@@ -10,7 +10,10 @@ resource "aws_config_config_rule" "rule" {
 
   source {
     owner             = "AWS"
-    source_identifier = each.value["identifier"]
+
+    # Custom rules don't have identifiers like AWS managed rules, so we need to
+    # fall back to the key if an identifier is not provided.
+    source_identifier = try(each.value["identifier"], upper(replace(each.key, "-", "_")))
   }
 
   input_parameters = (

--- a/modules/organization/main.tf
+++ b/modules/organization/main.tf
@@ -2,7 +2,10 @@ resource "aws_config_organization_managed_rule" "rule" {
   for_each = var.rules
 
   name                 = "${var.rule_name_prefix}${each.key}"
-  rule_identifier      = each.value["identifier"]
+
+  # Custom rules don't have identifiers like AWS managed rules, so we need to
+  # fall back to the key if an identifier is not provided.
+  rule_identifier      = try(each.value["identifier"], upper(replace(each.key, "-", "_")))
   excluded_accounts    = var.excluded_accounts
   description          = try(each.value["description"], "")
   resource_types_scope = try(each.value["resource_types_scope"], [])


### PR DESCRIPTION
Fixed an issue where the new `identifier` attribute was being lost in the merge between managed rules config and overrides provided by the user. Now, a user doesn't need to provide values for all attributes when overriding rule config.

Fixes https://github.com/niaid/terraform-aws-managed-config-rules/pull/48